### PR TITLE
 Large change to resolve URLs with paths or versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ resolve urls, links to a dat key using common methods
 * URLs with keys in them (`datproject.org/6161616161616161616161616161616161616161616161616161616161616161`)
 * `hyperdrive-key` or `dat-key` headers
 * Url to JSON http request that returns `{key: <dat-key>}`
+* Dat-DNS resolution ([details](https://github.com/beakerbrowser/beaker/wiki/Authenticated-Dat-URLs-and-HTTPS-to-Dat-Discovery))
 
 ## Install
 
@@ -40,6 +41,7 @@ Resolution order:
 1. Validate buffers or any strings with 64 character hashes in them via [dat-encoding](https://github.com/juliangruber/dat-encoding)
 2. Check headers in http request
 3. Check JSON request response for `key`
+4. Dat-DNS resolution via [dat-dns](https://github.com/datprotocol/dat-dns)
 
 ## Contributing
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
 var test = require('tape')
-var enc = require('dat-encoding')
 var datResolve = require('..')
+var enc = require('dat-encoding')
 
 // Strings that do not require lookup
 var stringKeys = [
@@ -21,27 +21,38 @@ var stringBadKeys = [
 test('resolve key with path', function (t) {
   t.plan(2)
   datResolve('87ed2e3b160f261a032af03921a3bd09227d0a4cde73466c17114816cae43336/path', function (err, newKey) {
-    console.log('KEYPATH', err, newKey)
     t.notOk(err, 'not expected error')
     t.ok(newKey, 'is a key')
   })
 })
 
-/*
-test('resolve hostname with path', function (t) {
+test('resolve https hostname with path', function (t) {
   t.plan(2)
-  datResolve('beakerbrowser.com/path', function (err, newKey) {
-    console.log('HOSTNAMEPATH', err, newKey)
+  datResolve('https://beakerbrowser.com/path', function (err, newKey) {
     t.notOk(err, 'not expected error')
     t.ok(newKey, 'is a key')
   })
 })
-*/
+
+test('resolve dat hostname with path', function (t) {
+  t.plan(2)
+  datResolve('dat://beakerbrowser.com/path', function (err, newKey) {
+    t.notOk(err, 'not expected error')
+    t.ok(newKey, 'is a key')
+  })
+})
+
+test('resolve hostname with path', function (t) {
+  t.plan(2)
+  datResolve('beakerbrowser.com/path', function (err, newKey) {
+    t.notOk(err, 'not expected error')
+    t.ok(newKey, 'is a key')
+  })
+})
 
 test('resolve key with version', function (t) {
   t.plan(2)
   datResolve('87ed2e3b160f261a032af03921a3bd09227d0a4cde73466c17114816cae43336+5', function (err, newKey) {
-    console.log('KEYVERSION', err, newKey)
     t.notOk(err, 'not expected error')
     t.ok(newKey, 'is a key')
   })
@@ -50,7 +61,6 @@ test('resolve key with version', function (t) {
 test('resolve hostname with version', function (t) {
   t.plan(2)
   datResolve('beakerbrowser.com+5', function (err, newKey) {
-    console.log('HOSTNAMEVERSION', err, newKey)
     t.notOk(err, 'not expected error')
     t.ok(newKey, 'is a key')
   })

--- a/test/index.js
+++ b/test/index.js
@@ -18,6 +18,44 @@ var stringBadKeys = [
   {type: 'invalid', key: '61616161616161616161616161616161616161616161616161616161616161612'}
 ]
 
+test('resolve key with path', function (t) {
+  t.plan(2)
+  datResolve('87ed2e3b160f261a032af03921a3bd09227d0a4cde73466c17114816cae43336/path', function (err, newKey) {
+    console.log('KEYPATH', err, newKey)
+    t.notOk(err, 'not expected error')
+    t.ok(newKey, 'is a key')
+  })
+})
+
+/*
+test('resolve hostname with path', function (t) {
+  t.plan(2)
+  datResolve('beakerbrowser.com/path', function (err, newKey) {
+    console.log('HOSTNAMEPATH', err, newKey)
+    t.notOk(err, 'not expected error')
+    t.ok(newKey, 'is a key')
+  })
+})
+*/
+
+test('resolve key with version', function (t) {
+  t.plan(2)
+  datResolve('87ed2e3b160f261a032af03921a3bd09227d0a4cde73466c17114816cae43336+5', function (err, newKey) {
+    console.log('KEYVERSION', err, newKey)
+    t.notOk(err, 'not expected error')
+    t.ok(newKey, 'is a key')
+  })
+})
+
+test('resolve hostname with version', function (t) {
+  t.plan(2)
+  datResolve('beakerbrowser.com+5', function (err, newKey) {
+    console.log('HOSTNAMEVERSION', err, newKey)
+    t.notOk(err, 'not expected error')
+    t.ok(newKey, 'is a key')
+  })
+})
+
 test('resolve bad key without http', function (t) {
   t.plan(2 * stringBadKeys.length) // 2 tests for 2 keys
   stringBadKeys.forEach(function (key) {


### PR DESCRIPTION
Allows it to resolve:

* hostname.com/path
* hostname.com+4
* dat://hostname.com/path
* a1b[...]3c4/path (64 char key)
* a1b[...]3c4+4
* dat://a1b[...]3c4/path

Depends on <https://github.com/juliangruber/dat-encoding/pull/23>

<https://github.com/millette/dat-shell/issues/5> depends on these changes.