### PR TITLE
Preventing catching of errors in the callback.

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,10 +16,11 @@ function resolve (link, cb) {
     // validates + removes dat://
     // also works for http urls with keys in them
     key = stringKey(link)
-    cb(null, key)
   } catch (e) {
     lookup()
+    return
   }
+  cb(null, key)
 
   function lookup () {
     // if it starts with http or dat: use as is, otherwise prepend http://

--- a/test/index.js
+++ b/test/index.js
@@ -118,3 +118,13 @@ test('resolve beaker browser dat', function (t) {
     t.end()
   })
 })
+
+test('callbacks are called out of a try/catch block', function (t) {
+  process.once('uncaughtException', function (err) {
+    t.equals(err.message, 'test', 'Making sure that the right error occurs')
+    t.end()
+  })
+  datResolve('dat://beakerbrowser.com', function () {
+    throw new Error('test')
+  })
+})


### PR DESCRIPTION
Putting the `cb` within the try & catch also catches eventual errors happening within the callback. This way an eventual error is just simply rethrown, which allows for easier debugging.